### PR TITLE
Fix andor7 bug, register front_back, clean up build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
   implementation(libs.common.utils.core)
   implementation(libs.kotlin.logging)
 
-  testImplementation(libs.readingbat.core)
   testImplementation(libs.kotest.runner)
   testImplementation(libs.kotest.assertions)
   testImplementation(libs.ktor.server.test)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ kotest = "6.1.7"
 kotlin = "2.3.20"
 ktor = "3.4.1"
 logging = "8.0.01"
-readingbat = "3.0.3"
+readingbat = "3.0.4"
 utils = "2.6.3"
 versions = "0.53.0"
 

--- a/python/boolean_exprs/andor7.py
+++ b/python/boolean_exprs/andor7.py
@@ -1,19 +1,19 @@
 # @desc Which order are the **and** and the **or** evaluated?
 
-def andor5(val1, val2, val3):
+def andor7(val1, val2, val3):
     result = val1 or val2 and val3
     return result
 
 
 def main():
-    print(andor5(True, True, True))
-    print(andor5(True, True, False))
-    print(andor5(True, False, True))
-    print(andor5(True, False, False))
-    print(andor5(False, True, True))
-    print(andor5(False, True, False))
-    print(andor5(False, False, True))
-    print(andor5(False, False, False))
+    print(andor7(True, True, True))
+    print(andor7(True, True, False))
+    print(andor7(True, False, True))
+    print(andor7(True, False, False))
+    print(andor7(False, True, True))
+    print(andor7(False, True, False))
+    print(andor7(False, False, True))
+    print(andor7(False, False, False))
 
 
 if __name__ == '__main__':

--- a/src/main/kotlin/Content.kt
+++ b/src/main/kotlin/Content.kt
@@ -111,6 +111,8 @@ val content =
         challenge("replace4") { returnType = StringType }
 
         challenge("count1") { returnType = IntType }
+
+        challenge("front_back") { returnType = StringType }
       }
     }
   }


### PR DESCRIPTION
## Summary

- **Fix runtime bug**: `andor7.py` defined `andor5()` instead of `andor7()`, causing `NameError` for every student submission on the andor7 challenge
- **Register dead challenge**: `front_back.py` existed in `python/warmup1/` but was never registered in `Content.kt` — added it to the warmup1 group
- **Remove redundant dependency**: `testImplementation(libs.readingbat.core)` is unnecessary since `implementation` already makes it available on the test classpath
- **Update readingbat to 3.0.4**

## Test plan

- [ ] Run `make tests` to verify andor7 challenge now passes
- [ ] Verify front_back challenge appears and works on the site
- [ ] Confirm build still compiles cleanly with the removed duplicate dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)