### PR TITLE
Add student hints to all Python challenge files

### DIFF
--- a/python/boolean_exprs/andor1.py
+++ b/python/boolean_exprs/andor1.py
@@ -1,4 +1,4 @@
-# @desc Truth tables
+# @desc The **and** operator returns True only when both values are True.
 
 def andor1(val1, val2):
     result = val1 and val2

--- a/python/boolean_exprs/andor2.py
+++ b/python/boolean_exprs/andor2.py
@@ -1,4 +1,4 @@
-# @desc Truth tables
+# @desc The **or** operator returns True when at least one value is True.
 
 def andor2(val1, val2):
     result = val1 or val2

--- a/python/boolean_exprs/less_than_or_equal.py
+++ b/python/boolean_exprs/less_than_or_equal.py
@@ -1,4 +1,4 @@
-# @desc Determine if one value is greater than or equal to another with the **<=** operator. Notice the **=** comes after the **<**.
+# @desc Determine if one value is less than or equal to another with the **<=** operator. Notice the **=** comes after the **<**.
 
 def less_than_or_equal(val1, val2):
     result = val1 <= val2

--- a/python/boolean_exprs/modulo1.py
+++ b/python/boolean_exprs/modulo1.py
@@ -1,6 +1,5 @@
 # @desc The **%** operator returns the remainder after dividing two numbers. See more details [here](https://blog.mattclemente.com/2019/07/12/modulus-operator-modulo-operation.html).
 
-
 def modulo1(num, mod):
     result = num % mod
     return result

--- a/python/for_loops/for_loop2.py
+++ b/python/for_loops/for_loop2.py
@@ -1,3 +1,5 @@
+# @desc A **for** loop iterates over each character in a string one at a time.
+
 def for_loop2(x):
     result = 0
     for i in x:

--- a/python/for_loops/for_loop4.py
+++ b/python/for_loops/for_loop4.py
@@ -1,3 +1,5 @@
+# @desc A **for** loop visits each character in a string; use **==** to compare characters.
+
 def for_loop4(str, x):
     result = 0
     for i in str:

--- a/python/for_loops/for_loop6.py
+++ b/python/for_loops/for_loop6.py
@@ -1,3 +1,5 @@
+# @desc A slice like **str[i:i+n]** extracts a substring of length **n** starting at index **i**.
+
 def for_loop6(str, x):
     result = 0
     xl = len(x)

--- a/python/if_stmts/if_stmt1.py
+++ b/python/if_stmts/if_stmt1.py
@@ -1,3 +1,5 @@
+# @desc When an **if** condition is False, execution skips to the code after the if block.
+
 def if_stmt1(x):
     if x > 10:
         return x

--- a/python/if_stmts/if_stmt2.py
+++ b/python/if_stmts/if_stmt2.py
@@ -1,3 +1,5 @@
+# @desc An **if/else** runs one branch or the other, but never both.
+
 def if_stmt2(x):
     if x > 10:
         return x + 5

--- a/python/if_stmts/if_stmt3.py
+++ b/python/if_stmts/if_stmt3.py
@@ -1,3 +1,5 @@
+# @desc With **and**, both conditions must be True for the **if** block to execute.
+
 def if_stmt3(x, y):
     if x > 10 and y:
         return x + 10

--- a/python/if_stmts/if_stmt4.py
+++ b/python/if_stmts/if_stmt4.py
@@ -1,3 +1,5 @@
+# @desc A boolean value like True or False can be used directly as a condition in an **if** statement.
+
 def if_stmt4(x, y, z):
     if x and y > z:
         return y

--- a/python/lists/list1.py
+++ b/python/lists/list1.py
@@ -1,3 +1,5 @@
+# @desc **range(x)** generates numbers from 0 up to (but not including) **x**.
+
 def list1(x):
     result = 0
     for i in range(x):

--- a/python/lists/list3.py
+++ b/python/lists/list3.py
@@ -1,3 +1,5 @@
+# @desc A **for** loop over a list visits each element; comparisons with **==** are case-sensitive.
+
 def list3(strs):
     result = 0
     for i in strs:

--- a/python/lists/list4.py
+++ b/python/lists/list4.py
@@ -1,3 +1,5 @@
+# @desc **list[x:]** returns a new list starting from index **x** to the end.
+
 def list4(strs, x):
     result = 0
     for i in strs[x:]:

--- a/python/lists/list5.py
+++ b/python/lists/list5.py
@@ -1,3 +1,5 @@
+# @desc **range(x, y, z)** generates numbers from **x** up to (but not including) **y**, stepping by **z**.
+
 def list5(x, y, z):
     result = []
     for i in range(x, y, z):

--- a/python/string_ops/concat2.py
+++ b/python/string_ops/concat2.py
@@ -1,3 +1,5 @@
+# @desc The **+** operator can combine multiple strings together in a single expression.
+
 def concat2(s1, s2, s3):
     result = s1 + s2 + s3
     return result

--- a/python/string_ops/concat3.py
+++ b/python/string_ops/concat3.py
@@ -1,3 +1,5 @@
+# @desc Using **+=** in a loop repeatedly appends to a string. Think about how many times the loop runs.
+
 def concat3(t, s):
     result = ''
     for i in range(t):

--- a/python/string_ops/goodbye_name.py
+++ b/python/string_ops/goodbye_name.py
@@ -1,3 +1,5 @@
+# @desc The **+** operator joins strings together exactly as they are, including any spaces you add.
+
 def goodbye_name(name):
     return 'Goodbye ' + name + '!'
 

--- a/python/warmup1/boolean_list.py
+++ b/python/warmup1/boolean_list.py
@@ -1,4 +1,4 @@
-# @desc This is a description of **boolean_list**
+# @desc Each element is compared with **>** to produce True or False, and the results are collected into a list.
 
 def above_five(vals):
     results = []

--- a/python/warmup1/count1.py
+++ b/python/warmup1/count1.py
@@ -1,3 +1,5 @@
+# @desc **x[i:i+2]** extracts a 2-character substring starting at index **i**. The loop checks every position.
+
 def count1(x):
     count = 0
     for i in range(len(x)):

--- a/python/warmup1/front_back.py
+++ b/python/warmup1/front_back.py
@@ -1,3 +1,5 @@
+# @desc **s[0]** is the first character and **s[-1]** is the last character of a string.
+
 def front_back(s):
     if (len(s) < 2):
         return s

--- a/python/warmup1/int_list.py
+++ b/python/warmup1/int_list.py
@@ -1,4 +1,4 @@
-# @desc This is a description of **int_list**
+# @desc The **if/else** inside the loop appends **1** or **0** depending on whether each value passes the test.
 
 def above_five(vals):
     results = []

--- a/python/warmup1/replace1.py
+++ b/python/warmup1/replace1.py
@@ -1,3 +1,5 @@
+# @desc **x[1:len(x)-1]** extracts the middle of a string, skipping the first and last characters.
+
 def replace1(x):
     str = 'hi' + x[1:len(x) - 1] + 'hi'
     return str

--- a/python/warmup1/replace2.py
+++ b/python/warmup1/replace2.py
@@ -1,3 +1,5 @@
+# @desc Trace through each **if** condition carefully. The first and last characters determine which branches run.
+
 def replace2(x):
     str = ''
     if x[0] != 'a':

--- a/python/warmup1/replace3.py
+++ b/python/warmup1/replace3.py
@@ -1,3 +1,5 @@
+# @desc String slicing can rearrange parts of a string. Pay attention to which indices select which characters.
+
 def replace3(x):
     if len(x) <= 4:
         return x

--- a/python/warmup1/replace4.py
+++ b/python/warmup1/replace4.py
@@ -1,3 +1,5 @@
+# @desc Compare the first and last characters to decide which branch executes. **x[len(x)-1]** is the last character.
+
 def replace4(x):
     if len(x) <= 1:
         return x

--- a/python/warmup1/simple_choice1.py
+++ b/python/warmup1/simple_choice1.py
@@ -1,4 +1,4 @@
-# @desc This is a description of **simple_choice1**
+# @desc The **not** operator flips True to False and False to True. Trace which branch the **if** takes.
 
 def simple_choice1(sunny):
     if (not sunny):

--- a/python/warmup1/simple_choice2.py
+++ b/python/warmup1/simple_choice2.py
@@ -1,4 +1,4 @@
-# @desc This is a description of **simple_choice2**
+# @desc The **or** operator is True when at least one side is True. Follow which branch runs for each combination.
 
 def simple_choice2(sunny, raining):
     if (sunny or raining):

--- a/python/warmup1/string_list.py
+++ b/python/warmup1/string_list.py
@@ -1,4 +1,4 @@
-# @desc This is a description of **string_list**
+# @desc The loop checks each value and appends either **'a'** or **'b'** to the result list based on the condition.
 
 def above_five(vals):
     results = []

--- a/python/warmup1/x_and_y.py
+++ b/python/warmup1/x_and_y.py
@@ -1,4 +1,4 @@
-# @desc This is a description of **x and y**
+# @desc **range(x)** runs the loop **x** times. Think about what value **z** ends up with after the loop finishes.
 
 def x_and_y(x, y):
     z = 0


### PR DESCRIPTION
## Summary

- **17 new hints** added to files that had no `@desc` line (for_loops, if_stmts, lists, string_ops, warmup1)
- **6 placeholder hints** replaced — "This is a description of **X**" → actual helpful hints
- **2 improved hints** — andor1/andor2 "Truth tables" → explains what `and`/`or` do
- **1 bug fix** — less_than_or_equal.py said "greater than" instead of "less than"
- All 60 `.py` files now have a `# @desc` line on line 1 followed by a blank line

All hints are 1-2 sentences targeted at 10th grade students. They explain the concept being tested (operators, slicing, loops) without revealing the answer.

## Test plan

- [ ] Run `make tests` to verify no challenge behavior changed
- [ ] Spot-check hints on the live site for clarity and formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)