### PR TITLE
Consolidate string literals and centralize versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: default clean build tests uberjar uber cc run heroku logs versioncheck upgrade-wrapper
 
+GRADLE_VERSION := $(shell awk -F'"' '/^gradle[[:space:]]*=/ {print $$2}' gradle/libs.versions.toml)
+
 default: versioncheck
 
 clean:
@@ -33,4 +35,4 @@ versioncheck:
 	./gradlew dependencyUpdates
 
 upgrade-wrapper:
-	./gradlew wrapper --gradle-version=9.5.0 --distribution-type=bin
+	./gradlew wrapper --gradle-version=$(GRADLE_VERSION) --distribution-type=bin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,25 +23,25 @@ dependencies {
 }
 
 kotlin {
-  jvmToolchain(17)
+  jvmToolchain(libs.versions.jvm.get().toInt())
 }
+
+val cleanTask = "clean"
+val buildTask = "build"
 
 tasks.register("stage") {
-  dependsOn("clean", "build")
+  dependsOn(cleanTask, buildTask)
 }
 
-tasks.named("build") {
-  mustRunAfter("clean")
+tasks.named(buildTask) {
+  mustRunAfter(cleanTask)
 }
 
 tasks.shadowJar {
   archiveFileName.set("server.jar")
   isZip64 = true
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-  exclude("META-INF/*.SF")
-  exclude("META-INF/*.DSA")
-  exclude("META-INF/*.RSA")
-  exclude("LICENSE*")
+  listOf("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA", "LICENSE*").forEach(::exclude)
 }
 
 tasks.test {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,6 @@
 [versions]
+gradle = "9.5.0"
+jvm = "17"
 kotest = "6.1.11"
 kotlin = "2.3.21"
 ktor = "3.4.3"


### PR DESCRIPTION
## Summary
- Move Gradle (`9.5.0`) and JVM (`17`) versions into `gradle/libs.versions.toml`
- Reference `libs.versions.jvm` from `build.gradle.kts` via `jvmToolchain(libs.versions.jvm.get().toInt())`
- Extract `GRADLE_VERSION` from the TOML in the `Makefile` for the `upgrade-wrapper` target
- Consolidate duplicate `"clean"`/`"build"` task name strings into vals and collapse four `exclude(...)` calls into a single `listOf(...).forEach(::exclude)` in `tasks.shadowJar`

## Test plan
- [ ] `make build`
- [ ] `make tests`
- [ ] `make -n upgrade-wrapper` shows the correct Gradle version expanded from the TOML

🤖 Generated with [Claude Code](https://claude.com/claude-code)