### PR TITLE
Add kotlinter/detekt tooling and Makefile help target

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,32 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+insert_final_newline = true
+max_line_length = 120
+trim_trailing_whitespace = true
+
+[build.gradle]
+indent_size = 4
+
+[{Makefile,makefile}]
+indent_style = tab
+indent_size = 4
+
+[*.{kt,kts}]
+ktlint_standard_final-newline = disabled
+ktlint_standard_no-wildcard-imports = disabled
+ktlint_standard_function-signature = disabled
+ktlint_standard_multiline-if-else = disabled
+ktlint_standard_class-signature = disabled
+ktlint_standard_string-template-indent = disabled
+ktlint_standard_no-multi-spaces = disabled
+ktlint_standard_class-naming = disabled
+ktlint_standard_indent = disabled
+ktlint_standard_property-naming = disabled
+ktlint_standard_no-empty-file = disabled
+ktlint_standard_no-consecutive-comments = disabled
+ktlint_standard_block-comment-initial-star-alignment = disabled
+ktlint_standard_chain-method-continuation = disabled

--- a/Makefile
+++ b/Makefile
@@ -1,38 +1,57 @@
-.PHONY: default clean build tests uberjar uber cc run heroku logs versioncheck upgrade-wrapper
+.PHONY: default help clean build lint format detekt detekt-baseline tests uberjar uber \
+		cc run heroku logs versioncheck upgrade-wrapper _require-gradle-version
 
 GRADLE_VERSION := $(shell awk -F'"' '/^gradle[[:space:]]*=/ {print $$2}' gradle/libs.versions.toml)
 
 default: versioncheck
 
-clean:
+help: ## Show this help
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+clean: ## Remove build artifacts
 	./gradlew clean
 
-build:
-	./gradlew build -xtest
+build: ## Build the project (skips tests)
+	./gradlew build -x test
 
-tests:
+lint: ## Run Kotlinter and detekt
+	./gradlew lintKotlin detekt
+
+format: ## Format Kotlin sources with kotlinter
+	./gradlew formatKotlin
+
+detekt: ## Run detekt static analysis
+	./gradlew detekt
+
+detekt-baseline: ## Generate detekt baseline file
+	./gradlew detektBaseline
+
+tests: ## Run all tests
 	./gradlew --rerun-tasks check
 
-uberjar:
+uberjar: ## Build the fat jar
 	./gradlew uberjar
 
-uber: uberjar
+uber: uberjar ## Build and run the fat jar
 	java -jar build/libs/server.jar
 
-cc:
-	./gradlew build --continuous -xtest
+cc: ## Continuous compilation (no tests)
+	./gradlew build --continuous -x test
 
-run:
+run: ## Start the server on port 8080
 	./gradlew run
 
-heroku:
+heroku: ## Push master to Heroku
 	git push heroku master
 
-logs:
+logs: ## Tail Heroku logs
 	heroku logs --tail
 
-versioncheck:
+versioncheck: ## Check for dependency updates (default target)
 	./gradlew dependencyUpdates
 
-upgrade-wrapper:
+upgrade-wrapper: _require-gradle-version ## Upgrade Gradle wrapper to version in libs.versions.toml
 	./gradlew wrapper --gradle-version=$(GRADLE_VERSION) --distribution-type=bin
+
+_require-gradle-version:
+	@[ -n "$(GRADLE_VERSION)" ] || { echo "ERROR: Could not determine gradle version from gradle/libs.versions.toml" >&2; exit 1; }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.versions)
   alias(libs.plugins.ktor.plugin)
+  alias(libs.plugins.detekt)
+  alias(libs.plugins.kotlinter)
 }
 
 // This is for ./gradlew run
@@ -24,6 +26,12 @@ dependencies {
 
 kotlin {
   jvmToolchain(libs.versions.jvm.get().toInt())
+}
+
+detekt {
+  source.setFrom("src/main/kotlin", "src/test/kotlin")
+  buildUponDefaultConfig = true
+  parallel = true
 }
 
 val cleanTask = "clean"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,13 @@
 [versions]
+detekt = "2.0.0-alpha.3"
 gradle = "9.5.0"
 jvm = "17"
 kotest = "6.1.11"
 kotlin = "2.3.21"
+kotlinter = "5.4.2"
 ktor = "3.4.3"
 logging = "8.0.02"
-readingbat = "3.1.5"
+readingbat = "3.1.8"
 utils = "2.8.2"
 versions = "0.54.0"
 
@@ -31,6 +33,8 @@ testing = [
 ]
 
 [plugins]
+detekt = { id = "dev.detekt", version.ref = "detekt" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter" }
 ktor-plugin = { id = "io.ktor.plugin", version.ref = "ktor" }
 versions = { id = "com.github.ben-manes.versions", version.ref = "versions" }

--- a/src/main/kotlin/Content.kt
+++ b/src/main/kotlin/Content.kt
@@ -18,7 +18,7 @@
 import com.pambrose.common.util.FileSystemSource
 import com.pambrose.common.util.GitHubRepo
 import com.pambrose.common.util.OwnerType.Organization
-import com.readingbat.dsl.ReturnType.*
+import com.readingbat.dsl.ReturnType
 import com.readingbat.dsl.isProduction
 import com.readingbat.dsl.readingBatContent
 
@@ -36,200 +36,200 @@ val content =
         packageName = "warmup1"
         description = "Warmup 1 challenges"
 
-        challenge("simple_choice1") { returnType = BooleanType }
+        challenge("simple_choice1") { returnType = ReturnType.BooleanType }
 
         challenge("simple_choice2") {
           codingBatEquiv = "p173401"
-          returnType = BooleanType
+          returnType = ReturnType.BooleanType
         }
 
-        challenge("boolean_list") { returnType = BooleanListType }
+        challenge("boolean_list") { returnType = ReturnType.BooleanListType }
 
-        challenge("int_list") { returnType = IntListType }
+        challenge("int_list") { returnType = ReturnType.IntListType }
 
-        challenge("string_list") { returnType = StringListType }
+        challenge("string_list") { returnType = ReturnType.StringListType }
 
-        challenge("x_and_y") { returnType = IntType }
+        challenge("x_and_y") { returnType = ReturnType.IntType }
 
-        challenge("replace1") { returnType = StringType }
+        challenge("replace1") { returnType = ReturnType.StringType }
 
-        challenge("replace2") { returnType = StringType }
+        challenge("replace2") { returnType = ReturnType.StringType }
 
-        challenge("replace3") { returnType = StringType }
+        challenge("replace3") { returnType = ReturnType.StringType }
 
-        challenge("replace4") { returnType = StringType }
+        challenge("replace4") { returnType = ReturnType.StringType }
 
-        challenge("count1") { returnType = IntType }
+        challenge("count1") { returnType = ReturnType.IntType }
 
-        challenge("front_back") { returnType = StringType }
+        challenge("front_back") { returnType = ReturnType.StringType }
       }
 
       group("Math Operations") {
         packageName = "math_ops"
         description = "Arithmetic operators, order of operations, and built-in math functions"
-        includeFilesWithType = "math*.py" returns IntType
+        includeFilesWithType = "math*.py" returns ReturnType.IntType
       }
 
       group("Boolean Expressions") {
         packageName = "boolean_exprs"
         description = "Basic boolean expressions"
 
-        challenge("less_than") { returnType = BooleanType }
-        challenge("greater_than") { returnType = BooleanType }
-        challenge("less_than_or_equal") { returnType = BooleanType }
-        challenge("greater_than_or_equal") { returnType = BooleanType }
-        challenge("equal") { returnType = BooleanType }
-        challenge("not_equal") { returnType = BooleanType }
-        challenge("modulo1") { returnType = IntType }
-        challenge("modulo2") { returnType = BooleanType }
-        challenge("modulo3") { returnType = BooleanType }
+        challenge("less_than") { returnType = ReturnType.BooleanType }
+        challenge("greater_than") { returnType = ReturnType.BooleanType }
+        challenge("less_than_or_equal") { returnType = ReturnType.BooleanType }
+        challenge("greater_than_or_equal") { returnType = ReturnType.BooleanType }
+        challenge("equal") { returnType = ReturnType.BooleanType }
+        challenge("not_equal") { returnType = ReturnType.BooleanType }
+        challenge("modulo1") { returnType = ReturnType.IntType }
+        challenge("modulo2") { returnType = ReturnType.BooleanType }
+        challenge("modulo3") { returnType = ReturnType.BooleanType }
 
-        includeFilesWithType = "andor*.py" returns BooleanType
+        includeFilesWithType = "andor*.py" returns ReturnType.BooleanType
       }
 
       group("Type Conversion") {
         packageName = "type_conv"
         description = "Converting between integers, strings, floats, and booleans"
 
-        challenge("type_conv1") { returnType = IntType }
-        challenge("type_conv2") { returnType = StringType }
-        challenge("type_conv3") { returnType = StringType }
-        challenge("type_conv4") { returnType = IntType }
-        challenge("type_conv5") { returnType = BooleanType }
-        challenge("type_conv6") { returnType = StringType }
-        challenge("type_conv7") { returnType = StringType }
-        challenge("type_conv8") { returnType = IntType }
-        challenge("type_conv9") { returnType = IntType }
-        challenge("type_conv10") { returnType = IntType }
+        challenge("type_conv1") { returnType = ReturnType.IntType }
+        challenge("type_conv2") { returnType = ReturnType.StringType }
+        challenge("type_conv3") { returnType = ReturnType.StringType }
+        challenge("type_conv4") { returnType = ReturnType.IntType }
+        challenge("type_conv5") { returnType = ReturnType.BooleanType }
+        challenge("type_conv6") { returnType = ReturnType.StringType }
+        challenge("type_conv7") { returnType = ReturnType.StringType }
+        challenge("type_conv8") { returnType = ReturnType.IntType }
+        challenge("type_conv9") { returnType = ReturnType.IntType }
+        challenge("type_conv10") { returnType = ReturnType.IntType }
       }
 
       group("If Statements") {
         packageName = "if_stmts"
         description = "Basic if statements"
-        includeFilesWithType = "if_stmt*.py" returns IntType
+        includeFilesWithType = "if_stmt*.py" returns ReturnType.IntType
       }
 
       group("String Operations") {
         packageName = "string_ops"
         description = "Basic string operations"
 
-        challenge("goodbye_name") { returnType = StringType }
-        challenge("combine1") { returnType = StringType }
-        challenge("combine2") { returnType = StringType }
-        includeFilesWithType = "concat*.py" returns StringType
-        includeFilesWithType = "strlen*.py" returns IntType
-        challenge("in_oper") { returnType = BooleanType }
-        challenge("starts_with") { returnType = BooleanType }
-        challenge("ends_with") { returnType = BooleanType }
-        includeFilesWithType = "slice*.py" returns StringType
-        challenge("split") { returnType = StringType }
+        challenge("goodbye_name") { returnType = ReturnType.StringType }
+        challenge("combine1") { returnType = ReturnType.StringType }
+        challenge("combine2") { returnType = ReturnType.StringType }
+        includeFilesWithType = "concat*.py" returns ReturnType.StringType
+        includeFilesWithType = "strlen*.py" returns ReturnType.IntType
+        challenge("in_oper") { returnType = ReturnType.BooleanType }
+        challenge("starts_with") { returnType = ReturnType.BooleanType }
+        challenge("ends_with") { returnType = ReturnType.BooleanType }
+        includeFilesWithType = "slice*.py" returns ReturnType.StringType
+        challenge("split") { returnType = ReturnType.StringType }
       }
 
       group("String Methods") {
         packageName = "string_methods"
         description = "Built-in string methods like upper(), lower(), replace(), and more"
 
-        challenge("upper1") { returnType = StringType }
-        challenge("lower1") { returnType = StringType }
-        challenge("strip1") { returnType = StringType }
-        challenge("replace_str1") { returnType = StringType }
-        challenge("find1") { returnType = IntType }
-        challenge("count_str1") { returnType = IntType }
-        challenge("title1") { returnType = StringType }
-        challenge("capitalize1") { returnType = StringType }
-        challenge("join1") { returnType = StringType }
-        challenge("isdigit1") { returnType = BooleanType }
-        challenge("swapcase1") { returnType = StringType }
-        challenge("split1") { returnType = StringListType }
+        challenge("upper1") { returnType = ReturnType.StringType }
+        challenge("lower1") { returnType = ReturnType.StringType }
+        challenge("strip1") { returnType = ReturnType.StringType }
+        challenge("replace_str1") { returnType = ReturnType.StringType }
+        challenge("find1") { returnType = ReturnType.IntType }
+        challenge("count_str1") { returnType = ReturnType.IntType }
+        challenge("title1") { returnType = ReturnType.StringType }
+        challenge("capitalize1") { returnType = ReturnType.StringType }
+        challenge("join1") { returnType = ReturnType.StringType }
+        challenge("isdigit1") { returnType = ReturnType.BooleanType }
+        challenge("swapcase1") { returnType = ReturnType.StringType }
+        challenge("split1") { returnType = ReturnType.StringListType }
       }
 
       group("For Loops") {
         packageName = "for_loops"
         description = "Basic for loops"
-        includeFilesWithType = "for_loop*.py" returns IntType
+        includeFilesWithType = "for_loop*.py" returns ReturnType.IntType
       }
 
       group("While Loops") {
         packageName = "while_loops"
         description = "Loops that repeat while a condition is true"
 
-        challenge("while_loop1") { returnType = IntType }
-        challenge("while_loop2") { returnType = IntType }
-        challenge("while_loop3") { returnType = IntType }
-        challenge("while_loop4") { returnType = IntType }
-        challenge("while_loop5") { returnType = IntType }
-        challenge("while_loop6") { returnType = IntType }
-        challenge("while_loop7") { returnType = StringType }
-        challenge("while_loop8") { returnType = StringType }
-        challenge("while_loop9") { returnType = IntType }
-        challenge("while_loop10") { returnType = StringType }
+        challenge("while_loop1") { returnType = ReturnType.IntType }
+        challenge("while_loop2") { returnType = ReturnType.IntType }
+        challenge("while_loop3") { returnType = ReturnType.IntType }
+        challenge("while_loop4") { returnType = ReturnType.IntType }
+        challenge("while_loop5") { returnType = ReturnType.IntType }
+        challenge("while_loop6") { returnType = ReturnType.IntType }
+        challenge("while_loop7") { returnType = ReturnType.StringType }
+        challenge("while_loop8") { returnType = ReturnType.StringType }
+        challenge("while_loop9") { returnType = ReturnType.IntType }
+        challenge("while_loop10") { returnType = ReturnType.StringType }
       }
 
       group("Lists") {
         packageName = "lists"
         description = "Basic list challenges"
-        includeFilesWithType = "list*.py" returns IntType
+        includeFilesWithType = "list*.py" returns ReturnType.IntType
       }
 
       group("Nested Loops") {
         packageName = "nested_loops"
         description = "Loops inside loops"
 
-        challenge("nested1") { returnType = IntType }
-        challenge("nested2") { returnType = IntType }
-        challenge("nested3") { returnType = IntType }
-        challenge("nested4") { returnType = IntType }
-        challenge("nested5") { returnType = StringType }
-        challenge("nested6") { returnType = IntType }
-        challenge("nested7") { returnType = IntType }
-        challenge("nested8") { returnType = BooleanType }
-        challenge("nested9") { returnType = IntType }
+        challenge("nested1") { returnType = ReturnType.IntType }
+        challenge("nested2") { returnType = ReturnType.IntType }
+        challenge("nested3") { returnType = ReturnType.IntType }
+        challenge("nested4") { returnType = ReturnType.IntType }
+        challenge("nested5") { returnType = ReturnType.StringType }
+        challenge("nested6") { returnType = ReturnType.IntType }
+        challenge("nested7") { returnType = ReturnType.IntType }
+        challenge("nested8") { returnType = ReturnType.BooleanType }
+        challenge("nested9") { returnType = ReturnType.IntType }
       }
 
       group("Tuples") {
         packageName = "tuples"
         description = "Immutable sequences and tuple operations"
 
-        challenge("tuple1") { returnType = StringType }
-        challenge("tuple2") { returnType = IntType }
-        challenge("tuple3") { returnType = StringType }
-        challenge("tuple4") { returnType = BooleanType }
-        challenge("tuple5") { returnType = StringType }
-        challenge("tuple6") { returnType = IntType }
-        challenge("tuple7") { returnType = IntType }
-        challenge("tuple8") { returnType = IntType }
-        challenge("tuple9") { returnType = IntType }
+        challenge("tuple1") { returnType = ReturnType.StringType }
+        challenge("tuple2") { returnType = ReturnType.IntType }
+        challenge("tuple3") { returnType = ReturnType.StringType }
+        challenge("tuple4") { returnType = ReturnType.BooleanType }
+        challenge("tuple5") { returnType = ReturnType.StringType }
+        challenge("tuple6") { returnType = ReturnType.IntType }
+        challenge("tuple7") { returnType = ReturnType.IntType }
+        challenge("tuple8") { returnType = ReturnType.IntType }
+        challenge("tuple9") { returnType = ReturnType.IntType }
       }
 
       group("Dictionaries") {
         packageName = "dictionaries"
         description = "Key-value data storage with Python dictionaries"
 
-        challenge("dict1") { returnType = IntType }
-        challenge("dict2") { returnType = IntType }
-        challenge("dict3") { returnType = BooleanType }
-        challenge("dict4") { returnType = StringType }
-        challenge("dict5") { returnType = IntType }
-        challenge("dict6") { returnType = StringListType }
-        challenge("dict7") { returnType = IntListType }
-        challenge("dict8") { returnType = IntType }
-        challenge("dict9") { returnType = IntType }
-        challenge("dict10") { returnType = StringType }
+        challenge("dict1") { returnType = ReturnType.IntType }
+        challenge("dict2") { returnType = ReturnType.IntType }
+        challenge("dict3") { returnType = ReturnType.BooleanType }
+        challenge("dict4") { returnType = ReturnType.StringType }
+        challenge("dict5") { returnType = ReturnType.IntType }
+        challenge("dict6") { returnType = ReturnType.StringListType }
+        challenge("dict7") { returnType = ReturnType.IntListType }
+        challenge("dict8") { returnType = ReturnType.IntType }
+        challenge("dict9") { returnType = ReturnType.IntType }
+        challenge("dict10") { returnType = ReturnType.StringType }
       }
 
       group("List Comprehensions") {
         packageName = "list_comps"
         description = "Building lists with concise one-line expressions"
 
-        challenge("list_comp1") { returnType = StringListType }
-        challenge("list_comp2") { returnType = IntListType }
-        challenge("list_comp3") { returnType = IntListType }
-        challenge("list_comp4") { returnType = StringListType }
-        challenge("list_comp5") { returnType = IntListType }
-        challenge("list_comp6") { returnType = IntListType }
-        challenge("list_comp7") { returnType = IntListType }
-        challenge("list_comp8") { returnType = StringListType }
-        challenge("list_comp9") { returnType = IntListType }
+        challenge("list_comp1") { returnType = ReturnType.StringListType }
+        challenge("list_comp2") { returnType = ReturnType.IntListType }
+        challenge("list_comp3") { returnType = ReturnType.IntListType }
+        challenge("list_comp4") { returnType = ReturnType.StringListType }
+        challenge("list_comp5") { returnType = ReturnType.IntListType }
+        challenge("list_comp6") { returnType = ReturnType.IntListType }
+        challenge("list_comp7") { returnType = ReturnType.IntListType }
+        challenge("list_comp8") { returnType = ReturnType.StringListType }
+        challenge("list_comp9") { returnType = ReturnType.IntListType }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Add kotlinter and detekt Gradle plugins (with a `detekt { ... }` config block) and bump `readingbat` to 3.1.8
- Expand the Makefile with a self-documenting `help` target plus `lint`, `format`, `detekt`, and `detekt-baseline` targets; switch `-xtest` to the canonical `-x test`; reorder `.PHONY`
- Add an `.editorconfig` that pins charset/EOL/indent and disables ktlint rules that conflict with the existing Kotlin style
- Replace wildcard `ReturnType.*` import in `Content.kt` with explicit `ReturnType` qualifier to satisfy the new lint config

## Test plan
- [ ] `make help` lists every annotated target
- [ ] `make lint` runs `lintKotlin` and `detekt` cleanly
- [ ] `make format` rewrites Kotlin sources via `formatKotlin`
- [ ] `make build` and `make tests` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)