### PR TITLE
Document tooling changes and add CHANGELOG/RELEASE_NOTES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Kotlinter Gradle plugin (`org.jmailen.kotlinter` 5.4.2) wired into the build for Kotlin lint and formatting.
+- Detekt Gradle plugin (`dev.detekt` 2.0.0-alpha.3) with a `detekt { ... }` configuration block.
+- `.editorconfig` pinning charset, end-of-line, indent style, and ktlint rule overrides so kotlinter aligns with the project's existing Kotlin style.
+- Makefile targets: `help` (self-documenting target list), `lint`, `format`, `detekt`, `detekt-baseline`.
+- Makefile guard `_require-gradle-version` that fails fast if the Gradle version cannot be read from `gradle/libs.versions.toml`.
+
+### Changed
+- Bumped `readingbat-core` to 3.1.8.
+- `Content.kt` now imports `ReturnType` directly instead of `ReturnType.*`; all challenge registrations qualify return types (e.g., `ReturnType.IntType`).
+- Makefile `build` and `cc` targets use the canonical `-x test` flag instead of `-xtest`.
+- Reordered `.PHONY` to match the in-file target definition order.
+
+## [Pre-Unreleased history]
+
+Prior changes were tracked only via Git history; see `git log` for details.
+Notable recent work includes:
+
+- Consolidated string literals and centralized versions (#12).
+- Fixed the Gradle 9.5 build, refreshed dependencies, and aligned make targets (#11).
+- Bumped the Gradle wrapper to 9.5.0.
+- Bumped Kotlin to 2.3.21, Ktor to 3.4.3, ReadingBat to 3.1.4, Utils to 2.8.1; added `readingbat-kotest` test dependency.
+- Added 80 new challenges across 8 new topic groups.
+- Improved student hints across all Python challenge files.
+
+[Unreleased]: https://github.com/readingbat/readingbat-python-content/commits/master

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,10 +19,10 @@ ReadingBat Python content repository — Python programming challenges served vi
 ### Content DSL (Content.kt)
 
 Challenges are registered two ways:
-1. **Individually**: `challenge("name") { returnType = BooleanType }` — explicit per-file
-2. **Bulk via glob**: `includeFilesWithType = "pattern*.py" returns Type` — auto-includes matching files
+1. **Individually**: `challenge("name") { returnType = ReturnType.BooleanType }` — explicit per-file
+2. **Bulk via glob**: `includeFilesWithType = "pattern*.py" returns ReturnType.Type` — auto-includes matching files
 
-Return types: `BooleanType`, `StringType`, `IntType`, `BooleanListType`, `IntListType`, `StringListType`
+Return types (referenced via the `ReturnType` enum): `BooleanType`, `StringType`, `IntType`, `BooleanListType`, `IntListType`, `StringListType`. `Content.kt` imports `ReturnType` directly rather than wildcard-importing its members, so always qualify (e.g., `ReturnType.IntType`) when adding entries.
 
 **Source switching**: Production reads from GitHub (`GitHubRepo`); development reads from local filesystem (`FileSystemSource`), controlled by `isProduction()`.
 
@@ -51,22 +51,28 @@ Tests use Ktor's `testApplication` with ReadingBat's `TestSupport` DSL. The DSL 
 
 ## Development Commands
 
+Run `make help` for a self-documenting list. Common targets:
+
 ```bash
-make build            # Build without tests (./gradlew build -xtest)
+make build            # Build without tests (./gradlew build -x test)
 make tests            # Run all tests (./gradlew --rerun-tasks check)
 make run              # Start the server (./gradlew run), port 8080
 make cc               # Continuous compilation, no tests
+make lint             # Run kotlinter (lintKotlin) + detekt
+make format           # Format Kotlin sources via formatKotlin
+make detekt           # Run detekt static analysis only
+make detekt-baseline  # Regenerate the detekt baseline file
 make versioncheck     # Check dependency updates
 make upgrade-wrapper  # Upgrade Gradle wrapper
 make uberjar          # Build fat jar
 make uber             # Build and run fat jar (java -jar build/libs/server.jar)
 ```
 
-JVM toolchain: Java 17. Testing: Kotest with JUnit5 platform.
+JVM toolchain: Java 17. Testing: Kotest with JUnit5 platform. Lint/format: kotlinter + detekt, configured via `.editorconfig` (ktlint rule overrides) and the `detekt { ... }` block in `build.gradle.kts`.
 
 ## Adding a New Challenge
 
 1. Create `python/<group_dir>/challenge_name.py` following the file pattern above
-2. Register in `Content.kt` — either add a `challenge()` call or ensure filename matches an existing `includeFilesWithType` glob
+2. Register in `Content.kt` — either add a `challenge()` call or ensure filename matches an existing `includeFilesWithType` glob (qualify return types as `ReturnType.IntType`, etc.)
 3. The return type in `Content.kt` must match what the Python function actually returns
-4. Run `make tests` to verify the challenge works end-to-end
+4. Run `make lint` to catch style issues, then `make tests` to verify the challenge works end-to-end

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ make tests      # Run all tests
 make run        # Start the server on port 8080
 ```
 
+Run `make help` to see every available target. Other common ones:
+
+```bash
+make lint       # Run kotlinter + detekt
+make format     # Format Kotlin sources
+make cc         # Continuous compilation while you edit
+make uber       # Build and run the fat jar
+```
+
 ## Adding a Challenge
 
 1. Create a Python file in `python/<group_dir>/` following this pattern:
@@ -31,6 +40,6 @@ if __name__ == '__main__':
     main()
 ```
 
-2. Register the challenge in `src/main/kotlin/Content.kt` — either add a `challenge()` call or ensure the filename matches an existing `includeFilesWithType` glob.
+2. Register the challenge in `src/main/kotlin/Content.kt` — either add a `challenge()` call or ensure the filename matches an existing `includeFilesWithType` glob. Return types are qualified, e.g., `ReturnType.IntType`.
 
-3. Run `make tests` to verify.
+3. Run `make lint` then `make tests` to verify.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,41 @@
+# Release Notes
+
+## Unreleased — Kotlinter, detekt, and Makefile help
+
+This release focuses on developer ergonomics and code-style enforcement. No
+runtime behavior, content, or public DSL has changed.
+
+### Highlights
+
+- **Kotlin linting and formatting.** The build now applies the
+  [kotlinter](https://github.com/jeremymailen/kotlinter-gradle) Gradle plugin.
+  Run `make lint` to check Kotlin sources, and `make format` to apply fixes.
+- **Detekt static analysis.** Detekt is wired up via the `dev.detekt` plugin
+  and a `detekt { ... }` block in `build.gradle.kts`. Use `make detekt` to run
+  it standalone, or `make detekt-baseline` to (re)generate the baseline.
+- **Self-documenting Makefile.** Run `make help` for a colorized list of every
+  target, generated from `## ` annotations in the Makefile itself.
+- **`.editorconfig`.** New file pinning charset, EOL, indent width, and the
+  set of ktlint rules disabled to match the existing Kotlin style.
+- **Dependency bump.** `readingbat-core` updated from 3.1.5 to 3.1.8.
+
+### Source-level changes
+
+- `Content.kt` no longer wildcard-imports `ReturnType.*`; all return types are
+  qualified (e.g., `ReturnType.IntType`). When adding new challenges, use the
+  qualified form.
+- The Makefile uses the canonical `-x test` flag (with a space) in `build` and
+  `cc` targets, replacing the deprecated `-xtest` short form.
+
+### Upgrade notes
+
+- After pulling, run `./gradlew --refresh-dependencies` (or `make build`) once
+  so the new plugins resolve.
+- Existing developer workflows are unchanged; the new `lint` / `format`
+  targets are optional but recommended before pushing.
+
+### Full diff
+
+See the [compare view on
+GitHub](https://github.com/readingbat/readingbat-python-content/compare/179e26e...master)
+for the complete set of changes since the previous merge.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,15 +34,18 @@ detekt {
   parallel = true
 }
 
-val cleanTask = "clean"
-val buildTask = "build"
-
-tasks.register("stage") {
-  dependsOn(cleanTask, buildTask)
+kotlinter {
+  ignoreFormatFailures = false
+  ignoreLintFailures = false
+  reporters = arrayOf("checkstyle", "plain")
 }
 
-tasks.named(buildTask) {
-  mustRunAfter(cleanTask)
+tasks.register("stage") {
+  dependsOn("clean", "build")
+}
+
+tasks.named("build") {
+  mustRunAfter("clean")
 }
 
 tasks.shadowJar {
@@ -56,7 +59,7 @@ tasks.test {
   useJUnitPlatform()
 
   testLogging {
-    events = setOf(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
+    events = setOf(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED, TestLogEvent.STANDARD_ERROR)
     exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
     showStandardStreams = false
   }

--- a/llms.txt
+++ b/llms.txt
@@ -18,10 +18,10 @@ Two-language system: Kotlin defines and serves challenges; Python files are the 
 ## Content DSL
 
 Challenges are registered in Content.kt two ways:
-- Individually: `challenge("name") { returnType = BooleanType }`
-- Bulk via glob: `includeFilesWithType = "pattern*.py" returns Type`
+- Individually: `challenge("name") { returnType = ReturnType.BooleanType }`
+- Bulk via glob: `includeFilesWithType = "pattern*.py" returns ReturnType.Type`
 
-Return types: BooleanType, StringType, IntType, BooleanListType, IntListType, StringListType
+Return types (via the `ReturnType` enum, always qualified): BooleanType, StringType, IntType, BooleanListType, IntListType, StringListType
 
 Production reads from GitHub; development reads from local filesystem.
 
@@ -31,15 +31,19 @@ Each .py file has: a `# @desc` comment, a function implementing the challenge, a
 
 ## Development
 
+- List all targets: `make help`
 - Build: `make build`
 - Test: `make tests`
 - Run server: `make run`
 - Continuous build: `make cc`
+- Lint (kotlinter + detekt): `make lint`
+- Format Kotlin sources: `make format`
 - JVM toolchain: Java 17
 - Testing: Kotest with JUnit5
+- Lint/format: kotlinter + detekt, configured via `.editorconfig` and `build.gradle.kts`
 
 ## Adding Challenges
 
 1. Create `python/<group_dir>/challenge_name.py` with function and main() test cases
-2. Register in Content.kt with correct return type
-3. Run `make tests` to verify
+2. Register in Content.kt with correct return type (qualified, e.g. `ReturnType.IntType`)
+3. Run `make lint` then `make tests` to verify


### PR DESCRIPTION
## Summary
- Update CLAUDE.md, README.md, and llms.txt to document the new `lint`/`format`/`detekt`/`detekt-baseline` Make targets, the qualified `ReturnType.X` convention, and the `-x test` flag.
- Add CHANGELOG.md (Keep a Changelog format) and RELEASE_NOTES.md seeded with an Unreleased section describing the kotlinter/detekt rollout.
- Tighten `build.gradle.kts`: drop the unused `cleanTask`/`buildTask` locals, add a `kotlinter { ... }` config block (checkstyle + plain reporters, fail on lint/format errors), and surface `STANDARD_ERROR` in test logging.

## Test plan
- [ ] `make help` still renders cleanly
- [ ] `make lint` passes against the current tree
- [ ] `make build` and `make tests` succeed
- [ ] CHANGELOG and RELEASE_NOTES render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)