### PR TITLE
Add GitHub Actions CI for lint and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint (kotlinter + detekt)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run lint
+        run: make lint
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-reports
+          path: |
+            build/reports/ktlint/
+            build/reports/detekt/
+          if-no-files-found: ignore
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run tests
+        run: make tests
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: |
+            build/reports/tests/
+            build/test-results/
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- New `.github/workflows/ci.yml` with two parallel jobs: `lint` (kotlinter + detekt via `make lint`) and `test` (`make tests`).
- Triggers on push to `master` and on pull requests targeting `master`; a `concurrency` group cancels stale runs on the same ref.
- Uses Temurin JDK 17 and `gradle/actions/setup-gradle@v4` for Gradle caching.
- Each job uploads its reports (`build/reports/ktlint/`, `build/reports/detekt/`, `build/reports/tests/`, `build/test-results/`) as artifacts, always — even on failure — for easier diagnosis.

## Test plan
- [ ] Workflow appears under the Actions tab on push of this PR
- [ ] `lint` job succeeds against the current tree
- [ ] `test` job succeeds against the current tree
- [ ] Artifacts are uploaded and downloadable from the run summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)